### PR TITLE
Declare statusCode variable before use

### DIFF
--- a/app-defaults.js
+++ b/app-defaults.js
@@ -42,6 +42,7 @@ function responder (result, response) {
 exports.errorHandler = K(errorHandler);
 function errorHandler (error, response) {
   var body;
+  var statusCode = error.statusCode || 500;
   if (error.toJSON) {
     // JSONify the error and respond with that data
     return responder(error.toJSON(), response);
@@ -53,7 +54,6 @@ function errorHandler (error, response) {
   }
 
   var contentType = 'text/plain';
-  var statusCode = error.statusCode || 500;
 
   // error handler failed as well
   response.writeHead(statusCode, {


### PR DESCRIPTION
Got introduced in 57cc823598ee90a59ad9bbf0ebfd0be9ecae8157.
The error handler itself crashed and exceptions from request handlers were silently swallowed.
It might be good if errors within web-pockets internals were never silently swallowed?
Also, I couldn't find a test that's throwing an error and testing the response :)

Edit: I remember now, there's #2 which improves error handling and has a test for it. Need anything done to get #2 in?
